### PR TITLE
fix: spork method has incorrect parameters types

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -268,7 +268,7 @@ RpcClient.callspec = {
   setGenerate: 'bool int',
   setTxFee: 'float',
   setMockTime: 'int',
-  spork: 'str str',
+  spork: 'str int',
   signMessage: 'str str',
   signRawTransaction: 'str str str str',
   stop: '',


### PR DESCRIPTION
Spork method had incorrect parameters types and that lead to an error