### PR TITLE
fix: сallback was already called

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -149,6 +149,7 @@ if (self.timeout) {
 
   req.on('timeout', () => {
     const err = new Error(`Timeout Error: ${options.timeout}ms exceeded`);
+    called = true;
     callback(err);
   });
 


### PR DESCRIPTION
Smoke tests were returning errors in CI:
```
Error: Callback was already called.
    at /usr/src/app/node_modules/async/dist/async.js:321:36
    at newCallback (/usr/src/app/node_modules/@dashevo/dashd-rpc/lib/index.js:59:7)
    at ClientRequest.<anonymous> (/usr/src/app/node_modules/@dashevo/dashd-rpc/lib/index.js:146:7)
    ...
```

Use of the debugger revealed information about the request/response sent in the first callback function, and timeout messages being sent to the callback function in a second run. This PR fixes it, although I'm not entirely sure if this is how the `called` variable is supposed to be used.