### PR TITLE
fix: wrong type of `sendRawTransaction` second argument

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -276,7 +276,7 @@ RpcClient.callspec = {
   resendWalletTransactions: '',
   sendFrom: 'str str float int str str',
   sendMany: 'str obj int str str bool bool',
-  sendRawTransaction: 'str bool bool',
+  sendRawTransaction: 'str float bool',
   sendToAddress: 'str float str str',
   sentinelPing: 'str',
   setAccount: '',


### PR DESCRIPTION
Re:
- https://github.com/dashevo/dashcore-node/pull/90
- https://github.com/dashevo/insight-ui/issues/75

```diff
- sendRawTransaction: 'str bool bool',
+ sendRawTransaction: 'str float bool',
```