### PR TITLE
bump to v18 to match dashcore v18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dashevo/dashd-rpc",
-  "version": "2.4.2",
+  "version": "18.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dashevo/dashd-rpc",
-      "version": "2.4.1",
+      "version": "18.0.0",
       "license": "MIT",
       "dependencies": {
         "async": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dashevo/dashd-rpc",
   "description": "Dash Client Library to connect to Dash Core (dashd) via RPC",
-  "version": "2.4.2",
+  "version": "18.0.0",
   "author": {
     "name": "Stephen Pair",
     "email": "stephen@bitpay.com"


### PR DESCRIPTION
DashCore v18 had some breaking changes. Let's sync to v18 to signify that any new breaking changes are actually patches to fix for v18.