### PR TITLE
style: add 'npm run version' for formatting version commit message

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
   "main": "lib/index.js",
   "scripts": {
     "test": "mocha test -R spec",
-    "coverage": "nyc npm run test"
+    "coverage": "nyc npm run test",
+    "version": "npm version -m \"chore(release): bump version to v%s\""
   },
   "dependencies": {
     "async": "^3.2.4",


### PR DESCRIPTION
`npm run version ...` will function exactly as `npm version ...`, with the following message template applied:

```txt
chore(release): bump version to v%s
```

Example:

```txt
chore(release): bump version to v18.0.2
```